### PR TITLE
Fixed bootstrap glyphicons destination directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,10 @@ module.exports = {
     }
 
     // Import glyphicons
-    app.import(path.join(bootstrapPath, 'fonts/bootstrap/glyphicons-halflings-regular.eot'), { destDir: '/fonts' });
-    app.import(path.join(bootstrapPath, 'fonts/bootstrap/glyphicons-halflings-regular.svg'), { destDir: '/fonts' });
-    app.import(path.join(bootstrapPath, 'fonts/bootstrap/glyphicons-halflings-regular.ttf'), { destDir: '/fonts' });
-    app.import(path.join(bootstrapPath, 'fonts/bootstrap/glyphicons-halflings-regular.woff'), { destDir: '/fonts' });
+    app.import(path.join(bootstrapPath, 'fonts/bootstrap/glyphicons-halflings-regular.eot'), { destDir: '/fonts/bootstrap' });
+    app.import(path.join(bootstrapPath, 'fonts/bootstrap/glyphicons-halflings-regular.svg'), { destDir: '/fonts/bootstrap' });
+    app.import(path.join(bootstrapPath, 'fonts/bootstrap/glyphicons-halflings-regular.ttf'), { destDir: '/fonts/bootstrap' });
+    app.import(path.join(bootstrapPath, 'fonts/bootstrap/glyphicons-halflings-regular.woff'), { destDir: '/fonts/bootstrap' });
 
     //symlinking bootstrap sass styles to app dir
     var destBootstrapSourcePath = path.join(modulePath, 'app/styles/bootstrap');


### PR DESCRIPTION
This fixes bootstrap glyphicons "Failed to load resource" errors.

![screen shot 2014-09-17 at 8 50 08 am](https://cloud.githubusercontent.com/assets/3123/4303018/e17fc4f0-3e60-11e4-8420-23b810166b69.png)
.
