### PR TITLE
Make sassOptions non-destructive

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,13 @@ module.exports = {
     var jsFiles         = options.components ? options.components : fs.readdirSync(path_join(modulePath, javascriptsPath));
 
 
-    app.options.sassOptions = {
-        includePaths: [ path_join(modulePath, bootstrapPath, 'stylesheets') ]
-    };
+  // Non-destructively add paths to SASS
+	if (! app.options.sassOptions.includePaths ) {
+		app.options.sassOptions.includePaths = [];
+	}
+	app.options.sassOptions.includePaths.push(path_join(modulePath, bootstrapPath, 'stylesheets'));
+	app.options.sassOptions.includePaths.push(path_join(modulePath, bootstrapPath, 'stylesheets/bootstrap'));
+	app.options.sassOptions.includePaths.push(path_join(modulePath, bootstrapPath, 'stylesheets/bootstrap/mixins'));
 
     // Import css from bootstrap
 


### PR DESCRIPTION
The existing implementation is destructive in the way it sets the sassOptions `includePaths` array. This small change ensures that if a user has already set this property bootstrap is just added to the stack. I've also added the "bootstrap" and "bootstrap/mixins" directories too so that you can be compact when selecting only a subset of modules.
